### PR TITLE
Push up work for adding intercepter hooks and examples for Elasticsea…

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/snippets/AwsSigningInterceptor.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/snippets/AwsSigningInterceptor.java
@@ -1,0 +1,32 @@
+package org.apache.beam.examples.snippets;
+
+import org.apache.http.HttpRequestInterceptor;
+
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import org.apache.beam.sdk.io.elasticsearch.ElasticsearchIO;
+
+public class AWSSigningAuthorizationInterceptorProvider implements ElasticsearchIO.AuthorizationInterceptorProvider {
+
+    private final String servicename;
+    private final String region;
+    private final String awsCredentialsProviderSerialized;
+
+    public AWSSigningAuthorizationInterceptorProvider(String servicename, String region, AwsCredentialsProvider credentialsProvider) {
+        this.awsCredentialsProviderSerialized =
+                AwsSerializableUtils.serializeAwsCredentialsProvider(credentialsProvider);
+        this.servicename = servicename;
+        this.region = region;
+    }
+
+    @Override
+    public HttpRequestInterceptor getAuthorizationRequestInterceptor() {
+        AWS4Signer signer = new AWS4Signer();
+        signer.setServiceName(this.servicename);
+        signer.setRegionName(this.region);
+        return new AWSRequestSigningApacheInterceptor(this.servicename, signer,
+                AwsSerializableUtils.deserializeAwsCredentialsProvider(this.awsCredentialsProviderSerialized));
+    }
+}

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsSigningUtils.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsSigningUtils.java
@@ -1,0 +1,29 @@
+package org.apache.beam.sdk.io.aws2.options;
+
+import org.apache.http.HttpRequestInterceptor;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import org.apache.beam.sdk.io.elasticsearch.AuthorizationInterceptorProvider;
+
+public class AWSSigningAuthorizationInterceptorProvider implements AuthorizationInterceptorProvider {
+
+    private final String servicename;
+    private final String region;
+    private final String awsCredentialsProviderSerialized;
+
+    public AWSSigningAuthorizationInterceptorProvider(String servicename, String region, AwsCredentialsProvider credentialsProvider) {
+        this.awsCredentialsProviderSerialized =
+                AwsSerializableUtils.serializeAwsCredentialsProvider(credentialsProvider);
+        this.servicename = servicename;
+        this.region = region;
+    }
+
+    @Override
+    public HttpRequestInterceptor getAuthorizationRequestInterceptor() {
+        AWS4Signer signer = new AWS4Signer();
+        signer.setServiceName(this.servicename);
+        signer.setRegionName(this.region);
+        return new AWSRequestSigningApacheInterceptor(this.servicename, signer,
+                AwsSerializableUtils.deserializeAwsCredentialsProvider(this.awsCredentialsProviderSerialized));
+    }
+}


### PR DESCRIPTION
Add authorization interceptor hooks to the ES IO driver and give examples of AWS IAM authorization

I got bogged down in some of the AWS details between their v1 and v2 SDKs, and the conventions they use in the Beam SDK, plus I wasn't ready to navigate getting this merged upstream

Before pushing this any further, I'd probably want to put feelers out on the dev mailing list and see if anyone would oppose this change (if the current sink is maintained by ES folks, they might not be thrilled, etc.), and figure out the CLA/Legal stuff, etc.

Another alternative approach would be to port a real Opensearch driver over, but at the time I investigated this, their java REST client was still in beta and pretty gnarly looking